### PR TITLE
Fix Animated Scoreboard not loading on startup

### DIFF
--- a/plugin/src/main/java/com/xism4/sternalboard/SternalBoardPlugin.java
+++ b/plugin/src/main/java/com/xism4/sternalboard/SternalBoardPlugin.java
@@ -32,6 +32,8 @@ public class SternalBoardPlugin extends JavaPlugin {
     public void onLoad() {
         this.animConfig = new BukkitConfiguration(this, "animated-board");
         this.config = new BukkitConfiguration(this, "config");
+
+        setAnimateScoreboard(config.get().getBoolean("settings.animated"));
     }
 
     @Override

--- a/plugin/src/main/java/com/xism4/sternalboard/SternalBoardPlugin.java
+++ b/plugin/src/main/java/com/xism4/sternalboard/SternalBoardPlugin.java
@@ -38,12 +38,12 @@ public class SternalBoardPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        LibraryLoader.loadLibs(this);
+
         loadScoreboardMgr();
         commandHandler();
         loadTabCompletions();
         eventHandler();
-
-        LibraryLoader.loadLibs(this);
 
         Bukkit.getScheduler().runTaskAsynchronously(this, () -> new Metrics(this, STERNAL_ID_METRICS));
     }


### PR DESCRIPTION
Fixed animated scoreboards not loading on startup and a small issue caused by the fix.

Ran the following tests:
1. Starting up the plugin with animated scoreboard enabled
2. Starting up the plugin with animated scoreboard disabled