### PR TITLE
Fix an IndexOutOfBounds exception being thrown when buffer is empty.

### DIFF
--- a/plugin/src/main/java/com/xism4/sternalboard/commands/completer/OldPaperTabCompleter.java
+++ b/plugin/src/main/java/com/xism4/sternalboard/commands/completer/OldPaperTabCompleter.java
@@ -1,6 +1,7 @@
 package com.xism4.sternalboard.commands.completer;
 
 import com.destroystokyo.paper.event.server.AsyncTabCompleteEvent;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
@@ -12,7 +13,7 @@ public final class OldPaperTabCompleter implements Listener {
     @EventHandler
     public void onTabComplete(AsyncTabCompleteEvent event) {
         final String buffer = event.getBuffer();
-        final String input = buffer.charAt(0) == '/' ? buffer.substring(1) : buffer;
+        final String input = !(event.getSender() instanceof ConsoleCommandSender && buffer.isEmpty()) && buffer.charAt(0) == '/' ? buffer.substring(1) : buffer;
         final String[] tokens = input.split(" ");
 
         if (tokens.length == 0) return;


### PR DESCRIPTION
Happened to stumble on an exception when pressing the `ESC` key twice in a screen on an Ubuntu server. I am not sure why this triggered the `AsyncTabAutoCompleteEvent`, but it did and it came with an empty buffer.

I added an extra check that ensures that if the sender is a `ConsoleCommandSender` and the buffer is empty, it does not throw an `IndexOutOfBoundsException` at `buffer#charAt(0)`.

I have not been able to test if this works, since some methods were missing (most likely not pushed to the main branch) and relocation of dependencies did not work when assembling the plugin with gradle. I am fairly sure though, that this would not pose any problems, as when a command is sent through console, it does not start with a '/' anyway.